### PR TITLE
update for kohler-anthem api changes: tenant_id first, device_id second

### DIFF
--- a/custom_components/kohler_anthem/const.py
+++ b/custom_components/kohler_anthem/const.py
@@ -6,7 +6,7 @@ DOMAIN = "kohler_anthem"
 CONF_API_RESOURCE = "api_resource"
 CONF_APIM_KEY = "apim_subscription_key"
 CONF_CLIENT_ID = "client_id"
-CONF_CUSTOMER_ID = "customer_id"
+CONF_TENANT_ID = "tenant_id"
 
 # Defaults
 DEFAULT_SCAN_INTERVAL = 2  # seconds

--- a/custom_components/kohler_anthem/light.py
+++ b/custom_components/kohler_anthem/light.py
@@ -69,7 +69,7 @@ async def async_setup_entry(
     client: KohlerAnthemClient = data["client"]
     coordinator = data["coordinator"]
     devices = data["device_info"]["devices"]
-    customer_id = data["customer_id"]
+    tenant_id = data["tenant_id"]
 
     entities = []
     for device in devices:
@@ -106,7 +106,7 @@ async def async_setup_entry(
                                 outlet_idx,
                                 outlet_config.outlet_type,
                                 configured_valves,
-                                customer_id,
+                                tenant_id,
                             )
                         )
 
@@ -132,14 +132,14 @@ class KohlerOutletLight(CoordinatorEntity, LightEntity):
         outlet_idx: int,
         outlet_type: int,
         all_valve_indices: list[int],
-        customer_id: str,
+        tenant_id: str,
     ) -> None:
         """Initialize the light entity."""
         super().__init__(coordinator)
         self._hass = hass
         self._client = client
         self._config_entry = config_entry
-        self._customer_id = customer_id
+        self._tenant_id = tenant_id
         self._device_id = device_id
         self._outlet_idx = outlet_idx
         self._valve_idx = valve_idx
@@ -365,9 +365,9 @@ class KohlerOutletLight(CoordinatorEntity, LightEntity):
             # All commands go to primary_valve1 - prefix byte routes to correct valve
             valve_control = ValveControlModel(primary_valve1=valve_hex)
             await self._client.control_valve(
+                self._tenant_id,
                 self._device_id,
                 valve_control,
-                tenant_id=self._customer_id,
             )
 
     async def _send_outlet_command(self, on: bool, flow: int) -> None:
@@ -407,9 +407,9 @@ class KohlerOutletLight(CoordinatorEntity, LightEntity):
         valve_control = ValveControlModel(primary_valve1=valve_hex)
 
         await self._client.control_valve(
+            self._tenant_id,
             self._device_id,
             valve_control,
-            tenant_id=self._customer_id,
         )
 
     def _calculate_mode(self, turning_on: bool) -> ValveMode:

--- a/custom_components/kohler_anthem/number.py
+++ b/custom_components/kohler_anthem/number.py
@@ -52,7 +52,7 @@ async def async_setup_entry(
     client: KohlerAnthemClient = data["client"]
     coordinator = data["coordinator"]
     devices = data["device_info"]["devices"]
-    customer_id = data["customer_id"]
+    tenant_id = data["tenant_id"]
 
     entities = []
     for device in devices:
@@ -82,7 +82,7 @@ async def async_setup_entry(
                             device_name,
                             valve_idx,
                             configured_valves,
-                            customer_id,
+                            tenant_id,
                         )
                     )
                     entities.append(
@@ -95,7 +95,7 @@ async def async_setup_entry(
                             device_name,
                             valve_idx,
                             configured_valves,
-                            customer_id,
+                            tenant_id,
                         )
                     )
 
@@ -135,14 +135,14 @@ class KohlerTemperatureNumber(CoordinatorEntity, NumberEntity):
         device_name: str,
         valve_idx: int,
         all_valve_indices: list[int],
-        customer_id: str,
+        tenant_id: str,
     ) -> None:
         """Initialize the number entity."""
         super().__init__(coordinator)
         self._hass = hass
         self._client = client
         self._config_entry = config_entry
-        self._customer_id = customer_id
+        self._tenant_id = tenant_id
         self._device_id = device_id
         self._valve_idx = valve_idx
         self._all_valve_indices = all_valve_indices
@@ -382,9 +382,9 @@ class KohlerTemperatureNumber(CoordinatorEntity, NumberEntity):
             # All commands go to primary_valve1 - prefix byte routes to correct valve
             valve_control = ValveControlModel(primary_valve1=valve_hex)
             await self._client.control_valve(
+                self._tenant_id,
                 self._device_id,
                 valve_control,
-                tenant_id=self._customer_id,
             )
 
     async def _send_valve_command(
@@ -406,9 +406,9 @@ class KohlerTemperatureNumber(CoordinatorEntity, NumberEntity):
         # All commands go to primary_valve1 - prefix byte routes to correct valve
         valve_control = ValveControlModel(primary_valve1=valve_hex)
         await self._client.control_valve(
+            self._tenant_id,
             self._device_id,
             valve_control,
-            tenant_id=self._customer_id,
         )
 
 
@@ -433,14 +433,14 @@ class KohlerFlowNumber(CoordinatorEntity, NumberEntity):
         device_name: str,
         valve_idx: int,
         all_valve_indices: list[int],
-        customer_id: str,
+        tenant_id: str,
     ) -> None:
         """Initialize the flow number entity."""
         super().__init__(coordinator)
         self._hass = hass
         self._client = client
         self._config_entry = config_entry
-        self._customer_id = customer_id
+        self._tenant_id = tenant_id
         self._device_id = device_id
         self._valve_idx = valve_idx
         self._all_valve_indices = all_valve_indices
@@ -598,9 +598,9 @@ class KohlerFlowNumber(CoordinatorEntity, NumberEntity):
             # All commands go to primary_valve1 - prefix byte routes to correct valve
             valve_control = ValveControlModel(primary_valve1=valve_hex)
             await self._client.control_valve(
+                self._tenant_id,
                 self._device_id,
                 valve_control,
-                tenant_id=self._customer_id,
             )
 
     async def _send_valve_command(
@@ -622,7 +622,7 @@ class KohlerFlowNumber(CoordinatorEntity, NumberEntity):
         # All commands go to primary_valve1 - prefix byte routes to correct valve
         valve_control = ValveControlModel(primary_valve1=valve_hex)
         await self._client.control_valve(
+            self._tenant_id,
             self._device_id,
             valve_control,
-            tenant_id=self._customer_id,
         )

--- a/custom_components/kohler_anthem/switch.py
+++ b/custom_components/kohler_anthem/switch.py
@@ -28,6 +28,7 @@ async def async_setup_entry(
     client: KohlerAnthemClient = data["client"]
     coordinator = data["coordinator"]
     devices = data["device_info"]["devices"]
+    tenant_id = data["tenant_id"]
 
     # Initialize zone sync state (default: True)
     if "zone_sync" not in data:
@@ -48,6 +49,7 @@ async def async_setup_entry(
                 config_entry,
                 device_id,
                 device_name,
+                tenant_id,
             )
         )
         entities.append(
@@ -77,12 +79,14 @@ class KohlerWarmupSwitch(CoordinatorEntity, SwitchEntity):
         config_entry: ConfigEntry,
         device_id: str,
         device_name: str,
+        tenant_id: str,
     ) -> None:
         """Initialize the switch."""
         super().__init__(coordinator)
         self._client = client
         self._config_entry = config_entry
         self._device_id = device_id
+        self._tenant_id = tenant_id
 
         device_name_slug = (device_name or "kohler_anthem").lower().replace(" ", "_")
         self._attr_unique_id = f"{device_id}_warmup"
@@ -111,13 +115,13 @@ class KohlerWarmupSwitch(CoordinatorEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Start warmup mode."""
-        await self._client.start_warmup(self._device_id)
+        await self._client.start_warmup(self._tenant_id, self._device_id)
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Stop warmup mode."""
-        await self._client.stop_warmup(self._device_id)
+        await self._client.stop_warmup(self._tenant_id, self._device_id)
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 


### PR DESCRIPTION
## Summary
- Updated all API calls to use new parameter order: `tenant_id` first, `device_id` second
- Renamed `customer_id` to `tenant_id` throughout for consistency with Kohler API
- Added `tenant_id` parameter to warmup switch (was missing)

Depends on: https://github.com/yon/kohler-anthem/pull/6

## Test plan
- [ ] Test preset selection (was returning 403 Forbidden)
- [ ] Test warmup toggle
- [ ] Test outlet/valve controls
- [ ] Test temperature/flow controls