### PR TITLE
feat: B2C_1A_signin OAuth config flow + reauth + ROPC migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 SHELL := /bin/bash
-.PHONY: help venv lint format check clean release bump-patch bump-minor bump-major
+.PHONY: help venv lint format test check clean release bump-patch bump-minor bump-major
 
 COMPONENT_DIR := custom_components/kohler_anthem
 MANIFEST := $(COMPONENT_DIR)/manifest.json
 VERSION := $(shell python3 -c "import json; print(json.load(open('$(MANIFEST)'))['version'])")
 VENV := .venv
 RUFF := $(VENV)/bin/ruff
+PYTHON := $(VENV)/bin/python3
 
 help:
 	@echo "Usage: make <target>"
@@ -14,7 +15,8 @@ help:
 	@echo "  venv        Create venv and install dev tools"
 	@echo "  lint        Run ruff linter"
 	@echo "  format      Format code with ruff"
-	@echo "  check       Run all checks (lint)"
+	@echo "  test        Run pytest unit tests"
+	@echo "  check       Run all checks (lint + test)"
 	@echo "  clean       Remove cache files"
 	@echo ""
 	@echo "Versioning:"
@@ -29,19 +31,22 @@ help:
 
 $(VENV)/bin/ruff:
 	@python3 -m venv $(VENV)
-	@$(VENV)/bin/pip install --quiet ruff
-	@echo "venv created with ruff installed"
+	@$(VENV)/bin/pip install --quiet ruff pytest
+	@echo "venv created with ruff and pytest installed"
 
 venv: $(VENV)/bin/ruff
 
 lint: $(VENV)/bin/ruff
-	@$(RUFF) check $(COMPONENT_DIR)
+	@$(RUFF) check $(COMPONENT_DIR) tests
 
 format: $(VENV)/bin/ruff
-	@$(RUFF) format $(COMPONENT_DIR)
-	@$(RUFF) check --fix $(COMPONENT_DIR)
+	@$(RUFF) format $(COMPONENT_DIR) tests
+	@$(RUFF) check --fix $(COMPONENT_DIR) tests
 
-check: lint
+test: $(VENV)/bin/ruff
+	@$(PYTHON) -m pytest tests/ -q
+
+check: lint test
 
 clean:
 	@find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -24,7 +24,22 @@ This integration uses the unofficial [kohler-anthem](https://pypi.org/project/ko
 
 ## Configuration
 
-The integration requires credentials extracted from the Kohler Konnect app. See the [Credential Extraction Guide](https://github.com/yon/kohler-anthem/blob/main/credential-extraction/README.md) for detailed instructions on obtaining your `client_id`, `api_resource`, and `apim_key`.
+The integration requires three credentials extracted from the Kohler Konnect app: `client_id`, `apim_subscription_key`, and `api_resource`. See the [Credential Extraction Guide](https://github.com/yon/kohler-anthem/blob/main/credential-extraction/README.md) for detailed instructions.
+
+### Setup walkthrough
+
+1. **Settings → Devices & Services → Add Integration → Kohler Anthem**.
+2. Paste the three extracted credentials and click **Submit**.
+3. The integration shows a **clickable authorize URL**. Open it in any browser and sign in with your Kohler account.
+4. After signing in, your browser will try to open a custom URL (`msauth.com.kohler.hermoth://auth?code=...`). It will fail — that's expected. **Copy the full URL from your browser's address bar** and paste it back into Home Assistant.
+5. Home Assistant exchanges the authorization code for tokens and creates the entry.
+6. Subsequent restarts use the persisted refresh token. No re-sign-in until the refresh token expires or is revoked, in which case Home Assistant surfaces a **Repairs** notification.
+
+> **Why this dance?** Kohler's backend started rejecting password-based (ROPC) tokens on shower-control endpoints in May 2026. The `B2C_1A_signin` policy the integration now uses requires an interactive sign-in like the official mobile app does. The custom redirect URI is the same one the official app registers, which keeps things simple — Home Assistant doesn't need to be reachable from your browser.
+
+### Migrating from older versions
+
+If you were running an earlier version that used your Kohler email + password, Home Assistant will surface a Repairs notification on first restart asking you to sign in via the browser. Walk through steps 3–5 above. Your existing entities and automations are preserved (the unique ID stays the same).
 
 ## Known Limitations
 

--- a/custom_components/kohler_anthem/__init__.py
+++ b/custom_components/kohler_anthem/__init__.py
@@ -4,30 +4,36 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import asdict
 from datetime import timedelta
 from typing import Any
 
-import voluptuous as vol
-
-from homeassistant.config_entries import ConfigEntry, SOURCE_IMPORT
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from kohler_anthem import (
+    KohlerAnthemClient,
+    KohlerAnthemError,
+    KohlerOAuthConfig,
+    ReauthRequired,
+    TokenInfo,
+)
+from kohler_anthem.models import DeviceState
+from kohler_anthem.mqtt import KohlerMqttClient
 
 from .const import (
     CONF_API_RESOURCE,
     CONF_APIM_KEY,
     CONF_CLIENT_ID,
     CONF_TENANT_ID,
+    CONF_TOKEN,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    OAUTH_REDIRECT_URI,
 )
-from kohler_anthem import KohlerAnthemClient, KohlerConfig
-from kohler_anthem.exceptions import KohlerAnthemError
-from kohler_anthem.models import DeviceState
-from kohler_anthem.mqtt import KohlerMqttClient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,78 +46,90 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
 ]
 
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_USERNAME): cv.string,
-                vol.Required(CONF_PASSWORD): cv.string,
-                vol.Required(CONF_CLIENT_ID): cv.string,
-                vol.Required(CONF_APIM_KEY): cv.string,
-                vol.Required(CONF_API_RESOURCE): cv.string,
-            }
+
+class _ConfigEntryTokenStore:
+    """TokenStore that persists into ``entry.data[CONF_TOKEN]``.
+
+    Keeps the refresh token alive across HA restarts. Updates go through
+    ``hass.config_entries.async_update_entry`` so the storage is durable
+    and survives reloads.
+    """
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        self._hass = hass
+        self._entry = entry
+
+    async def load(self) -> TokenInfo | None:
+        token_data = self._entry.data.get(CONF_TOKEN)
+        if not token_data:
+            return None
+        return TokenInfo(**token_data)
+
+    async def save(self, token: TokenInfo) -> None:
+        self._hass.config_entries.async_update_entry(
+            self._entry,
+            data={**self._entry.data, CONF_TOKEN: asdict(token)},
         )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
 
 
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up Kohler Anthem from YAML configuration."""
-    if DOMAIN not in config:
-        return True
+async def async_setup(hass: HomeAssistant, _config: dict[str, Any]) -> bool:
+    """Setup is config-flow-only — YAML import is no longer supported.
 
-    conf = config[DOMAIN]
-
-    # Check if already configured via config entry
-    for entry in hass.config_entries.async_entries(DOMAIN):
-        if entry.data.get(CONF_USERNAME) == conf[CONF_USERNAME]:
-            _LOGGER.debug("Kohler Anthem already configured via config entry")
-            return True
-
-    # Import YAML config as a config entry
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=conf,
-        )
-    )
-
+    Existing YAML configs (which carried a password) cannot be auto-imported
+    because the new flow requires interactive OAuth sign-in. Users on the old
+    path are migrated via reauth at config-entry setup time.
+    """
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Kohler Anthem from a config entry."""
-    config = KohlerConfig(
-        username=entry.data[CONF_USERNAME],
-        password=entry.data[CONF_PASSWORD],
+    # Migrate legacy ROPC entries (presence of CONF_PASSWORD): trigger reauth
+    # to walk the user through OAuth sign-in. The unique_id (username) is
+    # preserved across the migration so entities stay attached.
+    if CONF_PASSWORD in entry.data and CONF_TOKEN not in entry.data:
+        _LOGGER.warning(
+            "Legacy ROPC config entry detected for %s — starting OAuth migration",
+            entry.title,
+        )
+        raise ConfigEntryAuthFailed(
+            "Kohler now requires OAuth (B2C_1A_signin). Sign in again to migrate."
+        )
+
+    config = KohlerOAuthConfig(
         client_id=entry.data[CONF_CLIENT_ID],
         apim_subscription_key=entry.data[CONF_APIM_KEY],
         api_resource=entry.data[CONF_API_RESOURCE],
+        redirect_uri=OAUTH_REDIRECT_URI,
     )
     tenant_id = entry.data[CONF_TENANT_ID]
+    token_store = _ConfigEntryTokenStore(hass, entry)
 
-    client = KohlerAnthemClient(config)
+    client = KohlerAnthemClient(config, token_store=token_store)
 
     try:
         await client.connect()
+    except ReauthRequired as err:
+        _LOGGER.warning("OAuth refresh token rejected, prompting reauth: %s", err)
+        raise ConfigEntryAuthFailed(str(err)) from err
     except KohlerAnthemError as err:
         _LOGGER.error("Failed to connect to Kohler API: %s", err)
         return False
 
-    # Discover devices
     try:
         customer = await client.get_customer(tenant_id)
         devices = customer.get_all_devices()
         if not devices:
             _LOGGER.warning("No devices found for tenant %s", tenant_id)
+    except ReauthRequired as err:
+        _LOGGER.warning("OAuth refresh token rejected during discovery: %s", err)
+        await client.close()
+        raise ConfigEntryAuthFailed(str(err)) from err
     except KohlerAnthemError as err:
         _LOGGER.error("Failed to discover devices: %s", err)
         await client.close()
         return False
 
-    # Store device info
     device_info = {
         "customer": customer,
         "devices": devices,
@@ -128,6 +146,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 "states": states,
                 "devices": devices,
             }
+        except ReauthRequired as err:
+            raise ConfigEntryAuthFailed(str(err)) from err
         except KohlerAnthemError as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
@@ -141,14 +161,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    # Set up data storage first (needed by MQTT callback)
     hass.data.setdefault(DOMAIN, {})
     entry_data = {
         "client": client,
         "coordinator": coordinator,
         "device_info": device_info,
         "tenant_id": tenant_id,
-        "mqtt_client": None,  # Updated below if MQTT connects
+        "mqtt_client": None,
         # Local setpoints storage - API returns measured temp, not commanded setpoint
         # Format: {device_id: {valve_idx: {"temp": float, "flow": int}}}
         "setpoints": {},
@@ -158,7 +177,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
     hass.data[DOMAIN][entry.entry_id] = entry_data
 
-    # Initialize MQTT client for real-time updates (optional, don't fail if unavailable)
     try:
         _LOGGER.debug("Registering mobile device for IoT Hub credentials...")
         iot_hub_settings = await client.register_mobile_device(tenant_id)
@@ -168,18 +186,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
             async def delayed_refresh() -> None:
                 """Wait a moment then refresh coordinator."""
-                # Give the device time to execute the command and report new state
                 await asyncio.sleep(1.0)
                 await coordinator.async_request_refresh()
 
             def on_mqtt_message(topic: str, payload: bytes) -> None:
                 """Handle incoming MQTT messages and trigger coordinator refresh."""
                 _LOGGER.debug("MQTT message received, refreshing state")
-                # Clear local state - external change detected
-                # This forces entities to read from API state
                 entry_data["outlet_states"] = {}
                 entry_data["setpoints"] = {}
-                # Schedule a delayed coordinator refresh
                 hass.async_create_task(delayed_refresh())
 
             mqtt_client.add_callback(on_mqtt_message)
@@ -191,7 +205,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 _LOGGER.warning("Failed to connect to IoT Hub, using polling only")
         else:
             _LOGGER.warning("No IoT Hub settings received, using polling only")
-    except Exception as err:
+    except Exception as err:  # noqa: BLE001 — IoT Hub is best-effort
         _LOGGER.warning(
             "Failed to set up IoT Hub connection: %s (using polling only)", err
         )
@@ -205,13 +219,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         data = hass.data[DOMAIN].pop(entry.entry_id)
-
-        # Disconnect MQTT client
         if mqtt_client := data.get("mqtt_client"):
             await mqtt_client.disconnect()
-
-        # Close API client
         if client := data.get("client"):
             await client.close()
-
     return unload_ok
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate config entry from VERSION 1 (ROPC) to VERSION 2 (OAuth).
+
+    The actual credential migration happens via reauth in async_setup_entry —
+    here we just stamp the version so HA stops calling us. The reauth flow
+    strips CONF_PASSWORD and adds CONF_TOKEN.
+    """
+    if entry.version == 1:
+        new_data = {k: v for k, v in entry.data.items() if k != CONF_PASSWORD}
+        hass.config_entries.async_update_entry(entry, data=new_data, version=2)
+    return True

--- a/custom_components/kohler_anthem/_oauth_helpers.py
+++ b/custom_components/kohler_anthem/_oauth_helpers.py
@@ -1,0 +1,69 @@
+"""Pure helpers for the OAuth config flow — no Home Assistant imports.
+
+Lives in its own module so it can be unit-tested without the HA test harness.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from urllib.parse import parse_qs, urlparse
+
+
+def decode_jwt_oid(access_token: str) -> str | None:
+    """Pull the user's tenant id from the JWT (oid claim, falling back to sub).
+
+    Returns None on any decode error — callers should treat that as missing.
+    """
+    parts = access_token.split(".")
+    if len(parts) < 2:
+        return None
+    payload = parts[1]
+    payload += "=" * ((4 - len(payload) % 4) % 4)
+    try:
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    oid = claims.get("oid") or claims.get("sub")
+    return oid if isinstance(oid, str) else None
+
+
+def username_from_token(access_token: str) -> str | None:
+    """Best-effort: pull a human-readable identifier from the JWT.
+
+    B2C tokens carry ``emails`` (list) and ``name``; either is fine for the
+    entry title. Falls back to None so callers can use the tenant id.
+    """
+    parts = access_token.split(".")
+    if len(parts) < 2:
+        return None
+    payload = parts[1]
+    payload += "=" * ((4 - len(payload) % 4) % 4)
+    try:
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    emails = claims.get("emails")
+    if isinstance(emails, list) and emails and isinstance(emails[0], str):
+        return emails[0]
+    name = claims.get("name")
+    return name if isinstance(name, str) else None
+
+
+def extract_code_and_state(redirect_url: str) -> tuple[str | None, str | None, str | None]:
+    """Parse the URL the user pasted back from their browser.
+
+    Returns ``(code, state, error)``. Either ``code+state`` is set, or
+    ``error`` is. Custom redirect schemes (``msauth.com.kohler.hermoth://``)
+    parse fine via ``urllib.parse``.
+    """
+    parsed = urlparse(redirect_url)
+    params = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+    if "error" in params:
+        description = params.get("error_description") or params["error"]
+        return None, None, description
+    code = params.get("code")
+    state = params.get("state")
+    if not code or not state:
+        return None, None, "redirect URL did not contain code+state"
+    return code, state, None

--- a/custom_components/kohler_anthem/config_flow.py
+++ b/custom_components/kohler_anthem/config_flow.py
@@ -1,146 +1,326 @@
-"""Config flow for Kohler Anthem integration."""
+"""Config flow for Kohler Anthem integration.
+
+Replaces the legacy ROPC (username + password) flow with OAuth Authorization
+Code + PKCE against the B2C_1A_signin policy. Three-step flow:
+
+    1. ``user`` — collect ``client_id``, ``apim_subscription_key``,
+       ``api_resource`` (still per-user values from credential extraction).
+    2. ``authorize`` — show a clickable authorize URL and ask the user to
+       paste back the URL their browser ends up at after sign-in.
+    3. (internal) — exchange the code for tokens, persist, create entry.
+
+Reauth follows the same path; the existing entry's data is updated rather
+than a new entry created. YAML import is deliberately disabled — interactive
+sign-in cannot be carried in YAML.
+"""
 
 from __future__ import annotations
 
-import base64
-import json
 import logging
+import secrets
+from dataclasses import asdict
 from typing import Any
 
+import aiohttp
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from kohler_anthem import (
+    KohlerAnthemClient,
+    KohlerAnthemError,
+    KohlerOAuthAuth,
+    KohlerOAuthConfig,
+    TokenInfo,
+)
+
+from ._oauth_helpers import (
+    decode_jwt_oid,
+    extract_code_and_state,
+    username_from_token,
+)
 from .const import (
     CONF_API_RESOURCE,
     CONF_APIM_KEY,
     CONF_CLIENT_ID,
+    CONF_REDIRECT_URL,
     CONF_TENANT_ID,
+    CONF_TOKEN,
     DOMAIN,
+    OAUTH_REDIRECT_URI,
 )
-from kohler_anthem import KohlerAnthemClient, KohlerConfig
-from kohler_anthem.exceptions import AuthenticationError, KohlerAnthemError
 
 _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
         vol.Required(CONF_CLIENT_ID): cv.string,
         vol.Required(CONF_APIM_KEY): cv.string,
         vol.Required(CONF_API_RESOURCE): cv.string,
     }
 )
 
+STEP_AUTHORIZE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_REDIRECT_URL): cv.string,
+    }
+)
+
+
+class _StoreOnceTokenStore:
+    """Trivial TokenStore for use during the config flow.
+
+    The flow only needs to mint a token once and read it back in the same
+    step; runtime persistence is handled by HA's config-entry storage in
+    ``__init__.py`` after the entry exists.
+    """
+
+    def __init__(self) -> None:
+        self.token: TokenInfo | None = None
+
+    async def load(self) -> TokenInfo | None:
+        return self.token
+
+    async def save(self, token: TokenInfo) -> None:
+        self.token = token
+
 
 class KohlerAnthemConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Kohler Anthem."""
 
-    VERSION = 1
+    VERSION = 2
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._user_input: dict[str, Any] = {}
+        self._pkce_verifier: str = ""
+        self._state: str = ""
+        self._authorize_url: str = ""
+        self._reauth_entry: config_entries.ConfigEntry | None = None
+
+    # ------------------------------------------------------------------
+    # Step 1 — collect static credentials
+    # ------------------------------------------------------------------
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the initial step."""
-        if user_input is not None:
-            return await self._async_validate_and_create(user_input)
+        """Collect client_id / apim_key / api_resource, then start OAuth."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=STEP_USER_DATA_SCHEMA,
+                description_placeholders={
+                    "docs_url": "https://github.com/yon/ha-kohler-anthem#setup"
+                },
+            )
+
+        self._user_input = user_input
+        return await self._async_prepare_authorize_step()
+
+    # ------------------------------------------------------------------
+    # Step 2 — show authorize URL, collect pasted-back redirect URL
+    # ------------------------------------------------------------------
+
+    async def _async_prepare_authorize_step(self) -> FlowResult:
+        """Generate PKCE pair + authorize URL; render the authorize step."""
+        config = self._build_oauth_config()
+        verifier, challenge = KohlerOAuthAuth.generate_pkce_pair()
+        state = secrets.token_urlsafe(16)
+        # Build URL via the library so we never drift from how it's used at runtime.
+        auth = KohlerOAuthAuth(config, token_store=_StoreOnceTokenStore())
+        authorize_url = auth.build_authorize_url(state=state, code_challenge=challenge)
+
+        self._pkce_verifier = verifier
+        self._state = state
+        self._authorize_url = authorize_url
 
         return self.async_show_form(
-            step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            step_id="authorize",
+            data_schema=STEP_AUTHORIZE_SCHEMA,
             description_placeholders={
-                "docs_url": "https://github.com/yon/ha-kohler-anthem#setup"
+                "authorize_url": authorize_url,
+                "redirect_uri": OAUTH_REDIRECT_URI,
             },
         )
 
-    async def async_step_import(self, import_data: dict[str, Any]) -> FlowResult:
-        """Handle import from YAML configuration."""
-        return await self._async_validate_and_create(import_data)
-
-    async def _async_validate_and_create(
-        self, user_input: dict[str, Any]
+    async def async_step_authorize(
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Validate credentials and create config entry."""
-        errors: dict[str, str] = {}
+        if user_input is None:
+            return await self._async_prepare_authorize_step()
 
-        config = KohlerConfig(
-            username=user_input[CONF_USERNAME],
-            password=user_input[CONF_PASSWORD],
-            client_id=user_input[CONF_CLIENT_ID],
-            apim_subscription_key=user_input[CONF_APIM_KEY],
-            api_resource=user_input[CONF_API_RESOURCE],
-        )
+        code, state, error = extract_code_and_state(user_input[CONF_REDIRECT_URL])
+        if error or not code or not state:
+            _LOGGER.warning("OAuth redirect parse error: %s", error)
+            return self.async_show_form(
+                step_id="authorize",
+                data_schema=STEP_AUTHORIZE_SCHEMA,
+                errors={"base": "invalid_redirect"},
+                description_placeholders={
+                    "authorize_url": self._authorize_url,
+                    "redirect_uri": OAUTH_REDIRECT_URI,
+                },
+            )
+        if state != self._state:
+            _LOGGER.warning("OAuth state mismatch")
+            return self.async_show_form(
+                step_id="authorize",
+                data_schema=STEP_AUTHORIZE_SCHEMA,
+                errors={"base": "state_mismatch"},
+                description_placeholders={
+                    "authorize_url": self._authorize_url,
+                    "redirect_uri": OAUTH_REDIRECT_URI,
+                },
+            )
 
+        return await self._async_exchange_and_finish(code)
+
+    # ------------------------------------------------------------------
+    # Step 3 — exchange code, validate, create/update entry
+    # ------------------------------------------------------------------
+
+    async def _async_exchange_and_finish(self, code: str) -> FlowResult:
+        """Trade the code for tokens, verify it works, persist the entry."""
+        config = self._build_oauth_config()
+        store = _StoreOnceTokenStore()
+        auth = KohlerOAuthAuth(config, token_store=store)
+        session = async_get_clientsession(self.hass)
         try:
-            async with KohlerAnthemClient(config) as client:
-                tenant_id = self._get_tenant_id(client)
-                if tenant_id:
-                    customer = await client.get_customer(tenant_id)
-                    devices = customer.get_all_devices()
-                    if devices:
-                        _LOGGER.info(
-                            "Found %d device(s) for tenant %s",
-                            len(devices),
-                            tenant_id,
-                        )
-
-                    await self.async_set_unique_id(user_input[CONF_USERNAME].lower())
-                    self._abort_if_unique_id_configured()
-
-                    return self.async_create_entry(
-                        title=f"Kohler Anthem ({user_input[CONF_USERNAME]})",
-                        data={
-                            **user_input,
-                            CONF_TENANT_ID: tenant_id,
-                        },
-                    )
-                else:
-                    errors["base"] = "cannot_discover"
-
-        except AuthenticationError as err:
-            _LOGGER.error("Authentication failed: %s", err)
-            errors["base"] = "invalid_auth"
+            token = await auth.exchange_code_for_token(
+                session, code=code, code_verifier=self._pkce_verifier
+            )
         except KohlerAnthemError as err:
-            _LOGGER.error("API error: %s", err)
-            errors["base"] = "cannot_connect"
-        except Exception:
-            _LOGGER.exception("Unexpected exception")
-            errors["base"] = "unknown"
+            _LOGGER.error("Token exchange failed: %s", err)
+            return self.async_show_form(
+                step_id="authorize",
+                data_schema=STEP_AUTHORIZE_SCHEMA,
+                errors={"base": "token_exchange_failed"},
+                description_placeholders={
+                    "authorize_url": self._authorize_url,
+                    "redirect_uri": OAUTH_REDIRECT_URI,
+                    "error_detail": str(err),
+                },
+            )
+        except aiohttp.ClientError as err:
+            _LOGGER.error("Network error during token exchange: %s", err)
+            return self.async_show_form(
+                step_id="authorize",
+                data_schema=STEP_AUTHORIZE_SCHEMA,
+                errors={"base": "cannot_connect"},
+                description_placeholders={
+                    "authorize_url": self._authorize_url,
+                    "redirect_uri": OAUTH_REDIRECT_URI,
+                },
+            )
 
-        # For import, abort on error rather than showing form
-        if self.context.get("source") == config_entries.SOURCE_IMPORT:
-            return self.async_abort(reason=errors.get("base", "unknown"))
+        tenant_id = decode_jwt_oid(token.access_token)
+        if tenant_id is None:
+            _LOGGER.error("Could not extract tenant id from token claims")
+            return self.async_abort(reason="missing_tenant_id")
 
-        return self.async_show_form(
-            step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
-            errors=errors,
-            description_placeholders={
-                "docs_url": "https://github.com/yon/ha-kohler-anthem#setup"
-            },
+        token_data = asdict(token)
+        try:
+            await self._verify_credentials_work(config, token_data, tenant_id)
+        except KohlerAnthemError as err:
+            _LOGGER.error("Credential verification failed: %s", err)
+            return self.async_abort(reason="cannot_discover")
+
+        username = self._reauth_username() or username_from_token(token.access_token) or tenant_id
+        entry_data = {
+            CONF_USERNAME: username,
+            CONF_CLIENT_ID: self._user_input[CONF_CLIENT_ID],
+            CONF_APIM_KEY: self._user_input[CONF_APIM_KEY],
+            CONF_API_RESOURCE: self._user_input[CONF_API_RESOURCE],
+            CONF_TENANT_ID: tenant_id,
+            CONF_TOKEN: token_data,
+        }
+
+        if self._reauth_entry is not None:
+            self.hass.config_entries.async_update_entry(
+                self._reauth_entry, data=entry_data
+            )
+            await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
+            return self.async_abort(reason="reauth_successful")
+
+        await self.async_set_unique_id(username.lower())
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+            title=f"Kohler Anthem ({username})",
+            data=entry_data,
         )
 
-    def _get_tenant_id(self, client: KohlerAnthemClient) -> str | None:
-        """Extract tenant_id from the auth token."""
-        if client._auth.token and client._auth.token.access_token:
-            try:
-                # JWT is three base64 parts separated by dots
-                parts = client._auth.token.access_token.split(".")
-                if len(parts) >= 2:
-                    # Add padding if needed
-                    payload = parts[1]
-                    padding = 4 - len(payload) % 4
-                    if padding != 4:
-                        payload += "=" * padding
-                    decoded = base64.urlsafe_b64decode(payload)
-                    claims = json.loads(decoded)
-                    # The 'oid' claim is the user's object ID (tenant_id)
-                    return claims.get("oid") or claims.get("sub")
-            except Exception as err:
-                _LOGGER.warning("Could not decode access_token: %s", err)
+    async def _verify_credentials_work(
+        self,
+        config: KohlerOAuthConfig,
+        token_data: dict[str, Any],
+        tenant_id: str,
+    ) -> None:
+        """Connect with the new credentials and discover devices.
 
-        return None
+        Catches misconfigured app registrations / wrong APIM key early so the
+        user gets feedback before the entry is saved.
+        """
+        store = _StoreOnceTokenStore()
+        store.token = TokenInfo(**token_data)
+        client = KohlerAnthemClient(config, token_store=store)
+        await client.connect()
+        try:
+            customer = await client.get_customer(tenant_id)
+            devices = customer.get_all_devices()
+            _LOGGER.info("OAuth setup discovered %d device(s)", len(devices))
+        finally:
+            await client.close()
+
+    # ------------------------------------------------------------------
+    # YAML import — explicitly disabled (the legacy path required a password)
+    # ------------------------------------------------------------------
+
+    async def async_step_import(self, _import_data: dict[str, Any]) -> FlowResult:
+        return self.async_abort(reason="manual_oauth_required")
+
+    # ------------------------------------------------------------------
+    # Reauth (called by HA when the runtime raises ReauthRequired)
+    # ------------------------------------------------------------------
+
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> FlowResult:
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        if self._reauth_entry is None:
+            return self.async_abort(reason="reauth_unknown_entry")
+        # Reuse the static credentials from the existing entry; only the OAuth
+        # token is missing/expired.
+        self._user_input = {
+            CONF_CLIENT_ID: self._reauth_entry.data[CONF_CLIENT_ID],
+            CONF_APIM_KEY: self._reauth_entry.data[CONF_APIM_KEY],
+            CONF_API_RESOURCE: self._reauth_entry.data[CONF_API_RESOURCE],
+        }
+        return await self._async_prepare_authorize_step()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _build_oauth_config(self) -> KohlerOAuthConfig:
+        return KohlerOAuthConfig(
+            client_id=self._user_input[CONF_CLIENT_ID],
+            apim_subscription_key=self._user_input[CONF_APIM_KEY],
+            api_resource=self._user_input[CONF_API_RESOURCE],
+            redirect_uri=OAUTH_REDIRECT_URI,
+        )
+
+    def _reauth_username(self) -> str | None:
+        if self._reauth_entry is None:
+            return None
+        username = self._reauth_entry.data.get(CONF_USERNAME)
+        return username if isinstance(username, str) else None

--- a/custom_components/kohler_anthem/const.py
+++ b/custom_components/kohler_anthem/const.py
@@ -7,6 +7,15 @@ CONF_API_RESOURCE = "api_resource"
 CONF_APIM_KEY = "apim_subscription_key"
 CONF_CLIENT_ID = "client_id"
 CONF_TENANT_ID = "tenant_id"
+# OAuth additions (B2C_1A_signin Authorization Code + PKCE)
+CONF_TOKEN = "token"
+CONF_REDIRECT_URL = "redirect_url"
+
+# OAuth — same custom-scheme redirect that the official Kohler mobile apps use,
+# so it's already registered against the app. The user's HA browser can't
+# follow the custom scheme, which is the point: the browser shows the URL
+# and the user pastes it back into HA.
+OAUTH_REDIRECT_URI = "msauth.com.kohler.hermoth://auth"
 
 # Defaults
 DEFAULT_SCAN_INTERVAL = 2  # seconds

--- a/custom_components/kohler_anthem/manifest.json
+++ b/custom_components/kohler_anthem/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/yon/ha-kohler-anthem/issues",
-  "requirements": ["kohler-anthem==0.1.4"],
-  "version": "0.2.2"
+  "requirements": ["kohler-anthem==0.2.0"],
+  "version": "0.3.0"
 }

--- a/custom_components/kohler_anthem/strings.json
+++ b/custom_components/kohler_anthem/strings.json
@@ -2,32 +2,50 @@
   "config": {
     "step": {
       "user": {
-        "title": "Kohler Anthem Setup",
-        "description": "Enter your Kohler Konnect credentials and API keys. See [setup docs]({docs_url}) for instructions.",
+        "title": "Kohler Anthem setup — credentials",
+        "description": "Enter the API credentials extracted from the Kohler Konnect app. See [setup docs]({docs_url}) for instructions. After this step you'll be asked to sign in via your browser.",
         "data": {
-          "username": "Email",
-          "password": "Password",
           "client_id": "Client ID",
           "apim_subscription_key": "APIM Subscription Key",
           "api_resource": "API Resource"
         },
         "data_description": {
-          "username": "Your Kohler Konnect account email",
-          "password": "Your Kohler Konnect account password",
           "client_id": "OAuth client ID (from APK)",
           "apim_subscription_key": "Azure API Management key (from mitmproxy)",
           "api_resource": "API resource identifier (from APK)"
         }
+      },
+      "authorize": {
+        "title": "Kohler Anthem setup — sign in",
+        "description": "Open this URL in any browser and sign in:\n\n[Sign in to Kohler]({authorize_url})\n\nAfter signing in, your browser will try to open `{redirect_uri}` (a custom URL the official mobile app uses). The browser won't be able to follow it — it'll show an error page or a 'Open in app?' prompt. **Copy the full URL** (it should contain `?code=...&state=...`) and paste it below.",
+        "data": {
+          "redirect_url": "Redirect URL"
+        },
+        "data_description": {
+          "redirect_url": "The full URL your browser ends up at after signing in (starts with `msauth.com.kohler.hermoth://auth?code=...`)."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Kohler Anthem — sign in again",
+        "description": "Your refresh token has expired or been revoked. Open this URL in any browser and sign in:\n\n[Sign in to Kohler]({authorize_url})\n\nAfter signing in, paste the full redirect URL below.",
+        "data": {
+          "redirect_url": "Redirect URL"
+        }
       }
     },
     "error": {
-      "invalid_auth": "Invalid authentication credentials",
-      "cannot_connect": "Failed to connect to Kohler API",
-      "cannot_discover": "Could not discover devices. Check your credentials.",
-      "unknown": "An unexpected error occurred"
+      "invalid_redirect": "That URL didn't include `code` and `state`. Make sure you copied the entire address bar contents.",
+      "state_mismatch": "Security check failed (`state` mismatch). Restart the flow and sign in again.",
+      "token_exchange_failed": "Kohler rejected the authorization code. {error_detail}",
+      "cannot_connect": "Could not reach the Kohler token endpoint. Check your network."
     },
     "abort": {
-      "already_configured": "This account is already configured"
+      "already_configured": "This account is already configured.",
+      "cannot_discover": "Sign-in succeeded but device discovery failed. Check the APIM key and API resource.",
+      "manual_oauth_required": "Kohler now requires interactive sign-in. Please add the integration via the UI — YAML configuration is no longer supported.",
+      "missing_tenant_id": "The signed-in token did not contain a tenant id (`oid`/`sub`). This shouldn't happen — please open an issue.",
+      "reauth_successful": "Re-authentication successful.",
+      "reauth_unknown_entry": "Reauth flow could not find the original config entry."
     }
   }
 }

--- a/custom_components/kohler_anthem/translations/en.json
+++ b/custom_components/kohler_anthem/translations/en.json
@@ -2,32 +2,50 @@
   "config": {
     "step": {
       "user": {
-        "title": "Kohler Anthem Setup",
-        "description": "Enter your Kohler Konnect credentials and API keys. See [setup docs]({docs_url}) for instructions.",
+        "title": "Kohler Anthem setup — credentials",
+        "description": "Enter the API credentials extracted from the Kohler Konnect app. See [setup docs]({docs_url}) for instructions. After this step you'll be asked to sign in via your browser.",
         "data": {
-          "username": "Email",
-          "password": "Password",
           "client_id": "Client ID",
           "apim_subscription_key": "APIM Subscription Key",
           "api_resource": "API Resource"
         },
         "data_description": {
-          "username": "Your Kohler Konnect account email",
-          "password": "Your Kohler Konnect account password",
           "client_id": "OAuth client ID (from APK)",
           "apim_subscription_key": "Azure API Management key (from mitmproxy)",
           "api_resource": "API resource identifier (from APK)"
         }
+      },
+      "authorize": {
+        "title": "Kohler Anthem setup — sign in",
+        "description": "Open this URL in any browser and sign in:\n\n[Sign in to Kohler]({authorize_url})\n\nAfter signing in, your browser will try to open `{redirect_uri}` (a custom URL the official mobile app uses). The browser won't be able to follow it — it'll show an error page or a 'Open in app?' prompt. **Copy the full URL** (it should contain `?code=...&state=...`) and paste it below.",
+        "data": {
+          "redirect_url": "Redirect URL"
+        },
+        "data_description": {
+          "redirect_url": "The full URL your browser ends up at after signing in (starts with `msauth.com.kohler.hermoth://auth?code=...`)."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Kohler Anthem — sign in again",
+        "description": "Your refresh token has expired or been revoked. Open this URL in any browser and sign in:\n\n[Sign in to Kohler]({authorize_url})\n\nAfter signing in, paste the full redirect URL below.",
+        "data": {
+          "redirect_url": "Redirect URL"
+        }
       }
     },
     "error": {
-      "invalid_auth": "Invalid authentication credentials",
-      "cannot_connect": "Failed to connect to Kohler API",
-      "cannot_discover": "Could not discover devices. Check your credentials.",
-      "unknown": "An unexpected error occurred"
+      "invalid_redirect": "That URL didn't include `code` and `state`. Make sure you copied the entire address bar contents.",
+      "state_mismatch": "Security check failed (`state` mismatch). Restart the flow and sign in again.",
+      "token_exchange_failed": "Kohler rejected the authorization code. {error_detail}",
+      "cannot_connect": "Could not reach the Kohler token endpoint. Check your network."
     },
     "abort": {
-      "already_configured": "This account is already configured"
+      "already_configured": "This account is already configured.",
+      "cannot_discover": "Sign-in succeeded but device discovery failed. Check the APIM key and API resource.",
+      "manual_oauth_required": "Kohler now requires interactive sign-in. Please add the integration via the UI — YAML configuration is no longer supported.",
+      "missing_tenant_id": "The signed-in token did not contain a tenant id (`oid`/`sub`). This shouldn't happen — please open an issue.",
+      "reauth_successful": "Re-authentication successful.",
+      "reauth_unknown_entry": "Reauth flow could not find the original config entry."
     }
   }
 }

--- a/tests/test_oauth_helpers.py
+++ b/tests/test_oauth_helpers.py
@@ -1,0 +1,130 @@
+"""Tests for pure OAuth helpers used by the config flow.
+
+These functions live in `_oauth_helpers.py` so they can be tested without
+pulling in Home Assistant's test plugin (which is a heavy dependency for
+just three small functions).
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+from pathlib import Path
+
+# Load the helpers module directly so the test doesn't trigger the package
+# __init__.py (which imports `homeassistant`).
+_HELPERS_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "kohler_anthem"
+    / "_oauth_helpers.py"
+)
+_spec = importlib.util.spec_from_file_location("_oauth_helpers", _HELPERS_PATH)
+assert _spec is not None and _spec.loader is not None
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+decode_jwt_oid = _module.decode_jwt_oid
+extract_code_and_state = _module.extract_code_and_state
+username_from_token = _module.username_from_token
+
+
+def _fake_jwt(claims: dict) -> str:
+    """Build a JWT with the given payload claims (signature is junk — we don't verify)."""
+    header = base64.urlsafe_b64encode(b'{"alg":"RS256","typ":"JWT"}').rstrip(b"=").decode()
+    payload = (
+        base64.urlsafe_b64encode(json.dumps(claims).encode("utf-8")).rstrip(b"=").decode()
+    )
+    return f"{header}.{payload}.signature"
+
+
+# ---------------------------------------------------------------------------
+# decode_jwt_oid
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeJwtOid:
+    def test_returns_oid_when_present(self) -> None:
+        token = _fake_jwt({"oid": "tenant-123", "sub": "subject-456"})
+        assert decode_jwt_oid(token) == "tenant-123"
+
+    def test_falls_back_to_sub_when_oid_missing(self) -> None:
+        token = _fake_jwt({"sub": "subject-456"})
+        assert decode_jwt_oid(token) == "subject-456"
+
+    def test_returns_none_for_malformed_token(self) -> None:
+        assert decode_jwt_oid("not.a.real-jwt-payload") is None
+        assert decode_jwt_oid("nodots") is None
+        assert decode_jwt_oid("") is None
+
+    def test_returns_none_when_oid_is_not_a_string(self) -> None:
+        token = _fake_jwt({"oid": 12345, "sub": ["a", "b"]})
+        assert decode_jwt_oid(token) is None
+
+
+# ---------------------------------------------------------------------------
+# username_from_token
+# ---------------------------------------------------------------------------
+
+
+class TestUsernameFromToken:
+    def test_returns_first_email_when_present(self) -> None:
+        token = _fake_jwt({"emails": ["user@example.com"]})
+        assert username_from_token(token) == "user@example.com"
+
+    def test_falls_back_to_name(self) -> None:
+        token = _fake_jwt({"name": "Alice"})
+        assert username_from_token(token) == "Alice"
+
+    def test_returns_none_when_neither_present(self) -> None:
+        token = _fake_jwt({"oid": "x"})
+        assert username_from_token(token) is None
+
+    def test_returns_none_for_malformed(self) -> None:
+        assert username_from_token("garbage") is None
+
+
+# ---------------------------------------------------------------------------
+# extract_code_and_state
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCodeAndState:
+    def test_parses_loopback_url(self) -> None:
+        url = "http://127.0.0.1:8765/oauth/callback?code=abc&state=xyz"
+        code, state, error = extract_code_and_state(url)
+        assert code == "abc"
+        assert state == "xyz"
+        assert error is None
+
+    def test_parses_custom_scheme_url(self) -> None:
+        """The mobile app's redirect scheme parses correctly."""
+        url = "msauth.com.kohler.hermoth://auth?code=abc&state=xyz"
+        code, state, error = extract_code_and_state(url)
+        assert code == "abc"
+        assert state == "xyz"
+        assert error is None
+
+    def test_returns_error_when_b2c_returned_error(self) -> None:
+        url = (
+            "msauth.com.kohler.hermoth://auth?error=access_denied"
+            "&error_description=user%20cancelled"
+        )
+        code, state, error = extract_code_and_state(url)
+        assert code is None
+        assert state is None
+        assert "user cancelled" in (error or "")
+
+    def test_returns_error_when_code_missing(self) -> None:
+        url = "http://127.0.0.1:8765/oauth/callback?state=xyz"
+        code, state, error = extract_code_and_state(url)
+        assert code is None
+        assert state is None
+        assert error is not None
+
+    def test_returns_error_when_state_missing(self) -> None:
+        url = "http://127.0.0.1:8765/oauth/callback?code=abc"
+        code, state, error = extract_code_and_state(url)
+        assert code is None
+        assert state is None
+        assert error is not None


### PR DESCRIPTION
## Summary

- Replaces the ROPC (email + password) config flow with OAuth Authorization Code + PKCE against the `B2C_1A_signin` policy that the official Kohler apps use. Required to recover `/commands/gcs/*` access after Kohler's May 2026 backend change.
- Existing ROPC entries are migrated automatically: HA surfaces a reauth Repairs notification, the user signs in via their browser, the entry is updated in place. **No entity loss.**
- Token persists in `config_entry.data["token"]`; the library's refresh-with-rotation keeps it alive across HA restarts. When the refresh token itself expires, `ReauthRequired` → `ConfigEntryAuthFailed` → standard HA reauth UX.

> **Pairs with** [kohler-anthem PR #11](https://github.com/yon/kohler-anthem/pull/11) (library 0.2.0). Manifest's `requirements` is bumped to `kohler-anthem==0.2.0`.

## How the browser flow works

The custom redirect URI `msauth.com.kohler.hermoth://auth` is the same one the official iOS/Android apps register, so we know B2C accepts it. The user's HA browser can't follow the custom scheme, so after signing in they see an error / "Open in app?" prompt — they copy the URL from the address bar and paste it back into HA. This avoids needing HA itself to be browser-reachable, which would add a configuration burden for users behind reverse proxies / NAT.

## Changes

| File | Change |
|------|--------|
| `custom_components/kohler_anthem/config_flow.py` | Rewritten: 3-step flow (user → authorize → exchange), reauth path, YAML-import abort |
| `custom_components/kohler_anthem/_oauth_helpers.py` | NEW — pure helpers (JWT decode, redirect parse) split out for testability |
| `custom_components/kohler_anthem/__init__.py` | Uses `KohlerOAuthConfig` + `_ConfigEntryTokenStore`; reauth on `ReauthRequired`; legacy entry migration |
| `custom_components/kohler_anthem/const.py` | + `CONF_TOKEN`, `CONF_REDIRECT_URL`, `OAUTH_REDIRECT_URI` |
| `custom_components/kohler_anthem/strings.json` + `translations/en.json` | New steps/errors/aborts for the OAuth flow |
| `custom_components/kohler_anthem/manifest.json` | `version: 0.3.0`; `requirements: kohler-anthem==0.2.0` |
| `tests/test_oauth_helpers.py` | NEW — 13 tests for the pure helpers |
| `Makefile` | + `make test`; `make check` now runs lint + test |
| `README.md` | New setup walkthrough section |

## Test plan

- [x] `make check` — ruff clean, 13 helper tests pass.
- [x] Pure helpers tested: JWT `oid`/`sub` extraction, redirect URL parsing (custom scheme + loopback HTTP + B2C error responses + missing params), email/name extraction.
- [ ] Full HA flow validation (requires reviewer):
  - [ ] Remove integration if installed; add via UI.
  - [ ] Walk through credentials → authorize URL → browser sign-in → paste redirect URL.
  - [ ] Verify entities appear and a Kohler light/switch responds.
  - [ ] Restart HA — entities reconnect without re-prompting for sign-in (refresh token survives).
  - [ ] Manually invalidate the refresh token (e.g., delete it from `core.config_entries`) and verify HA surfaces a Repairs reauth notification.
  - [ ] Migrate from a legacy ROPC entry — Repairs prompts for OAuth, walking through preserves entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)