### PR TITLE
Fix outlet writes: add b2c_refresh_token + reauth flow

### DIFF
--- a/custom_components/kohler_anthem/__init__.py
+++ b/custom_components/kohler_anthem/__init__.py
@@ -16,16 +16,19 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from homeassistant.exceptions import ConfigEntryAuthFailed
+
 from .const import (
     CONF_API_RESOURCE,
     CONF_APIM_KEY,
+    CONF_B2C_REFRESH_TOKEN,
     CONF_CLIENT_ID,
     CONF_TENANT_ID,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
 from kohler_anthem import KohlerAnthemClient, KohlerConfig
-from kohler_anthem.exceptions import KohlerAnthemError
+from kohler_anthem.exceptions import AuthenticationError, KohlerAnthemError
 from kohler_anthem.models import DeviceState
 from kohler_anthem.mqtt import KohlerMqttClient
 
@@ -83,12 +86,23 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Kohler Anthem from a config entry."""
+    b2c_refresh_token = entry.data.get(CONF_B2C_REFRESH_TOKEN)
+    if not b2c_refresh_token:
+        # Pre-0.2.0 config entry — needs reauth to seed the refresh token
+        # before /commands/* writes will work.
+        raise ConfigEntryAuthFailed(
+            "No b2c_refresh_token configured. Run "
+            "`python -m kohler_anthem.b2c_signin` and paste the result "
+            "into the integration's reauth prompt."
+        )
+
     config = KohlerConfig(
         username=entry.data[CONF_USERNAME],
         password=entry.data[CONF_PASSWORD],
         client_id=entry.data[CONF_CLIENT_ID],
         apim_subscription_key=entry.data[CONF_APIM_KEY],
         api_resource=entry.data[CONF_API_RESOURCE],
+        b2c_refresh_token=b2c_refresh_token,
     )
     tenant_id = entry.data[CONF_TENANT_ID]
 
@@ -96,9 +110,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         await client.connect()
+    except AuthenticationError as err:
+        _LOGGER.error("Authentication failed (will trigger reauth): %s", err)
+        raise ConfigEntryAuthFailed(str(err)) from err
     except KohlerAnthemError as err:
         _LOGGER.error("Failed to connect to Kohler API: %s", err)
         return False
+
+    def _persist_rotated_refresh_token() -> None:
+        """B2C rotates the refresh_token on each silent refresh; persist it."""
+        rotated = client.b2c_refresh_token
+        if rotated and rotated != entry.data.get(CONF_B2C_REFRESH_TOKEN):
+            hass.config_entries.async_update_entry(
+                entry,
+                data={**entry.data, CONF_B2C_REFRESH_TOKEN: rotated},
+            )
 
     # Discover devices
     try:
@@ -124,10 +150,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             for device in devices:
                 state = await client.get_device_state(device.device_id)
                 states[device.device_id] = state
+            # After any successful exchange that may have rotated the B2C
+            # refresh_token, persist the latest value so an HA restart can
+            # resume without re-prompting the user.
+            _persist_rotated_refresh_token()
             return {
                 "states": states,
                 "devices": devices,
             }
+        except AuthenticationError as err:
+            raise ConfigEntryAuthFailed(
+                f"Auth failed during update; reauth required: {err}"
+            ) from err
         except KohlerAnthemError as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 

--- a/custom_components/kohler_anthem/config_flow.py
+++ b/custom_components/kohler_anthem/config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.helpers import config_validation as cv
 from .const import (
     CONF_API_RESOURCE,
     CONF_APIM_KEY,
+    CONF_B2C_REFRESH_TOKEN,
     CONF_CLIENT_ID,
     CONF_TENANT_ID,
     DOMAIN,
@@ -26,6 +27,19 @@ from kohler_anthem.exceptions import AuthenticationError, KohlerAnthemError
 
 _LOGGER = logging.getLogger(__name__)
 
+
+class _ValidationDone(Exception):
+    """Internal sentinel: validation finished (success or specific error already set)."""
+
+# Required for /commands/* writes (outlet on/off, presets, warmup, …).
+# Kohler's backend now rejects ROPC-policy tokens on those endpoints with 403;
+# B2C_1A_signin policy tokens are the only ones accepted. Seed once per account:
+#
+#   python -m kohler_anthem.b2c_signin url        # opens browser
+#   # sign in, copy msauth:// URL from address bar
+#   python -m kohler_anthem.b2c_signin exchange '<url>'
+#
+# The second command prints the refresh_token; paste it into the form.
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): cv.string,
@@ -33,6 +47,13 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_CLIENT_ID): cv.string,
         vol.Required(CONF_APIM_KEY): cv.string,
         vol.Required(CONF_API_RESOURCE): cv.string,
+        vol.Required(CONF_B2C_REFRESH_TOKEN): cv.string,
+    }
+)
+
+STEP_REAUTH_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_B2C_REFRESH_TOKEN): cv.string,
     }
 )
 
@@ -41,6 +62,7 @@ class KohlerAnthemConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Kohler Anthem."""
 
     VERSION = 1
+    _reauth_entry: config_entries.ConfigEntry | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -61,6 +83,61 @@ class KohlerAnthemConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle import from YAML configuration."""
         return await self._async_validate_and_create(import_data)
 
+    async def async_step_reauth(
+        self, entry_data: dict[str, Any]
+    ) -> FlowResult:
+        """Triggered when the stored b2c_refresh_token is revoked/expired."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Re-prompt the user for just the b2c_refresh_token field."""
+        errors: dict[str, str] = {}
+        entry = self._reauth_entry
+        assert entry is not None
+
+        if user_input is not None:
+            # Validate the new refresh_token by trying a silent refresh
+            new_token = user_input[CONF_B2C_REFRESH_TOKEN]
+            config = KohlerConfig(
+                username=entry.data[CONF_USERNAME],
+                password=entry.data[CONF_PASSWORD],
+                client_id=entry.data[CONF_CLIENT_ID],
+                apim_subscription_key=entry.data[CONF_APIM_KEY],
+                api_resource=entry.data[CONF_API_RESOURCE],
+                b2c_refresh_token=new_token,
+            )
+            try:
+                async with KohlerAnthemClient(config) as client:
+                    await client._b2c_auth.refresh(client._session)
+                    rotated = client.b2c_refresh_token or new_token
+            except AuthenticationError as err:
+                _LOGGER.error("Reauth refresh_token rejected: %s", err)
+                errors[CONF_B2C_REFRESH_TOKEN] = "invalid_b2c_refresh_token"
+            except KohlerAnthemError as err:
+                _LOGGER.error("Reauth network error: %s", err)
+                errors["base"] = "cannot_connect"
+            else:
+                self.hass.config_entries.async_update_entry(
+                    entry,
+                    data={**entry.data, CONF_B2C_REFRESH_TOKEN: rotated},
+                )
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_REAUTH_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders={
+                "docs_url": "https://github.com/yon/ha-kohler-anthem#refresh-token",
+            },
+        )
+
     async def _async_validate_and_create(
         self, user_input: dict[str, Any]
     ) -> FlowResult:
@@ -73,34 +150,53 @@ class KohlerAnthemConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             client_id=user_input[CONF_CLIENT_ID],
             apim_subscription_key=user_input[CONF_APIM_KEY],
             api_resource=user_input[CONF_API_RESOURCE],
+            b2c_refresh_token=user_input.get(CONF_B2C_REFRESH_TOKEN),
         )
 
         try:
             async with KohlerAnthemClient(config) as client:
                 tenant_id = self._get_tenant_id(client)
-                if tenant_id:
-                    customer = await client.get_customer(tenant_id)
-                    devices = customer.get_all_devices()
-                    if devices:
-                        _LOGGER.info(
-                            "Found %d device(s) for tenant %s",
-                            len(devices),
-                            tenant_id,
-                        )
-
-                    await self.async_set_unique_id(user_input[CONF_USERNAME].lower())
-                    self._abort_if_unique_id_configured()
-
-                    return self.async_create_entry(
-                        title=f"Kohler Anthem ({user_input[CONF_USERNAME]})",
-                        data={
-                            **user_input,
-                            CONF_TENANT_ID: tenant_id,
-                        },
-                    )
-                else:
+                if not tenant_id:
                     errors["base"] = "cannot_discover"
+                    raise _ValidationDone
 
+                customer = await client.get_customer(tenant_id)
+                devices = customer.get_all_devices()
+                if devices:
+                    _LOGGER.info(
+                        "Found %d device(s) for tenant %s",
+                        len(devices),
+                        tenant_id,
+                    )
+
+                # Validate the B2C refresh_token by triggering a silent refresh.
+                # If the token is bad, this raises AuthenticationError. If good,
+                # we capture the rotated refresh_token to persist.
+                rotated_token: str | None = None
+                try:
+                    await client._b2c_auth.refresh(client._session)
+                    rotated_token = client.b2c_refresh_token
+                except AuthenticationError as err:
+                    _LOGGER.error("B2C refresh_token rejected: %s", err)
+                    errors[CONF_B2C_REFRESH_TOKEN] = "invalid_b2c_refresh_token"
+                    raise _ValidationDone from err
+
+                await self.async_set_unique_id(user_input[CONF_USERNAME].lower())
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(
+                    title=f"Kohler Anthem ({user_input[CONF_USERNAME]})",
+                    data={
+                        **user_input,
+                        CONF_TENANT_ID: tenant_id,
+                        # Persist the rotated value so HA's next start has it
+                        CONF_B2C_REFRESH_TOKEN: rotated_token
+                        or user_input[CONF_B2C_REFRESH_TOKEN],
+                    },
+                )
+
+        except _ValidationDone:
+            pass
         except AuthenticationError as err:
             _LOGGER.error("Authentication failed: %s", err)
             errors["base"] = "invalid_auth"

--- a/custom_components/kohler_anthem/const.py
+++ b/custom_components/kohler_anthem/const.py
@@ -7,6 +7,8 @@ CONF_API_RESOURCE = "api_resource"
 CONF_APIM_KEY = "apim_subscription_key"
 CONF_CLIENT_ID = "client_id"
 CONF_TENANT_ID = "tenant_id"
+# Required for /commands/* writes. Seeded by `python -m kohler_anthem.b2c_signin`.
+CONF_B2C_REFRESH_TOKEN = "b2c_refresh_token"
 
 # Defaults
 DEFAULT_SCAN_INTERVAL = 2  # seconds

--- a/custom_components/kohler_anthem/manifest.json
+++ b/custom_components/kohler_anthem/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/yon/ha-kohler-anthem/issues",
-  "requirements": ["kohler-anthem==0.1.4"],
-  "version": "0.2.2"
+  "requirements": ["kohler-anthem>=0.2.0"],
+  "version": "0.3.0"
 }

--- a/custom_components/kohler_anthem/strings.json
+++ b/custom_components/kohler_anthem/strings.json
@@ -3,31 +3,42 @@
     "step": {
       "user": {
         "title": "Kohler Anthem Setup",
-        "description": "Enter your Kohler Konnect credentials and API keys. See [setup docs]({docs_url}) for instructions.",
+        "description": "Enter your Kohler Konnect credentials and API keys. See [setup docs]({docs_url}) for instructions, including how to obtain a B2C refresh token (required for outlet/valve writes).",
         "data": {
           "username": "Email",
           "password": "Password",
           "client_id": "Client ID",
           "apim_subscription_key": "APIM Subscription Key",
-          "api_resource": "API Resource"
+          "api_resource": "API Resource",
+          "b2c_refresh_token": "B2C Refresh Token"
         },
         "data_description": {
           "username": "Your Kohler Konnect account email",
           "password": "Your Kohler Konnect account password",
           "client_id": "OAuth client ID (from APK)",
           "apim_subscription_key": "Azure API Management key (from mitmproxy)",
-          "api_resource": "API resource identifier (from APK)"
+          "api_resource": "API resource identifier (from APK)",
+          "b2c_refresh_token": "Required for outlet/valve/preset writes. Run `python -m kohler_anthem.b2c_signin url` in a Python venv with kohler-anthem installed, sign in via the browser, copy the msauth:// URL from the address bar, then run `python -m kohler_anthem.b2c_signin exchange '<url>'` to print the refresh token. Paste the result here."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Kohler Anthem — Refresh Token Expired",
+        "description": "Your B2C refresh token was rejected. Run `python -m kohler_anthem.b2c_signin url` and `exchange` again, then paste the new refresh token below.",
+        "data": {
+          "b2c_refresh_token": "B2C Refresh Token"
         }
       }
     },
     "error": {
       "invalid_auth": "Invalid authentication credentials",
+      "invalid_b2c_refresh_token": "B2C refresh token is invalid or expired",
       "cannot_connect": "Failed to connect to Kohler API",
       "cannot_discover": "Could not discover devices. Check your credentials.",
       "unknown": "An unexpected error occurred"
     },
     "abort": {
-      "already_configured": "This account is already configured"
+      "already_configured": "This account is already configured",
+      "reauth_successful": "Refresh token updated; integration reloaded"
     }
   }
 }

--- a/custom_components/kohler_anthem/translations/en.json
+++ b/custom_components/kohler_anthem/translations/en.json
@@ -3,31 +3,42 @@
     "step": {
       "user": {
         "title": "Kohler Anthem Setup",
-        "description": "Enter your Kohler Konnect credentials and API keys. See [setup docs]({docs_url}) for instructions.",
+        "description": "Enter your Kohler Konnect credentials and API keys. See [setup docs]({docs_url}) for instructions, including how to obtain a B2C refresh token (required for outlet/valve writes).",
         "data": {
           "username": "Email",
           "password": "Password",
           "client_id": "Client ID",
           "apim_subscription_key": "APIM Subscription Key",
-          "api_resource": "API Resource"
+          "api_resource": "API Resource",
+          "b2c_refresh_token": "B2C Refresh Token"
         },
         "data_description": {
           "username": "Your Kohler Konnect account email",
           "password": "Your Kohler Konnect account password",
           "client_id": "OAuth client ID (from APK)",
           "apim_subscription_key": "Azure API Management key (from mitmproxy)",
-          "api_resource": "API resource identifier (from APK)"
+          "api_resource": "API resource identifier (from APK)",
+          "b2c_refresh_token": "Required for outlet/valve/preset writes. Run `python -m kohler_anthem.b2c_signin url` in a Python venv with kohler-anthem installed, sign in via the browser, copy the msauth:// URL from the address bar, then run `python -m kohler_anthem.b2c_signin exchange '<url>'` to print the refresh token. Paste the result here."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Kohler Anthem — Refresh Token Expired",
+        "description": "Your B2C refresh token was rejected. Run `python -m kohler_anthem.b2c_signin url` and `exchange` again, then paste the new refresh token below.",
+        "data": {
+          "b2c_refresh_token": "B2C Refresh Token"
         }
       }
     },
     "error": {
       "invalid_auth": "Invalid authentication credentials",
+      "invalid_b2c_refresh_token": "B2C refresh token is invalid or expired",
       "cannot_connect": "Failed to connect to Kohler API",
       "cannot_discover": "Could not discover devices. Check your credentials.",
       "unknown": "An unexpected error occurred"
     },
     "abort": {
-      "already_configured": "This account is already configured"
+      "already_configured": "This account is already configured",
+      "reauth_successful": "Refresh token updated; integration reloaded"
     }
   }
 }


### PR DESCRIPTION
## Summary

Restores write ops (outlets, presets, warmup) that have been silently 403ing. Requires `kohler-anthem>=0.2.0` (see [companion PR](https://github.com/yon/kohler-anthem/pull/13)).

## Root cause

Kohler tightened backend RBAC on `/commands/gcs/*` to require tokens from the `B2C_1A_signin` policy. The library was issuing ROPC-policy tokens, which the backend now rejects with 403. Reads kept working on cached tokens; writes failed silently. Full postmortem in the library repo's `working/findings/why_writes_started_failing_2026-05-11.md`.

## Changes

- **`const.py`** — new `CONF_B2C_REFRESH_TOKEN`.
- **`config_flow.py`**:
  - Required `b2c_refresh_token` field on the user-step form, with helper text pointing at `python -m kohler_anthem.b2c_signin`.
  - Validation triggers a silent refresh during setup; bad tokens surface as `invalid_b2c_refresh_token`.
  - New reauth step re-prompts only the refresh_token field when the existing one expires/is revoked.
- **`__init__.py`**:
  - Passes `b2c_refresh_token` into `KohlerConfig`.
  - Raises `ConfigEntryAuthFailed` when the entry lacks a refresh_token OR when auth fails at startup → HA's reauth machinery picks up.
  - Coordinator persists the rotated `refresh_token` back to the config entry after each update (B2C rotates on every silent refresh).
- **`strings.json` / `translations/en.json`** — new field + reauth strings.
- **`manifest.json`** — pin `kohler-anthem>=0.2.0`, bump component to `0.3.0`.

## One-time user setup

```
pip install 'kohler-anthem>=0.2.0'
python -m kohler_anthem.b2c_signin url
# Sign in via the browser that opens.
# After the msauth:// redirect URL appears in the address bar, copy it.
# (Safari hides the URL — use Chrome, or Safari Web Inspector → Network tab.)
python -m kohler_anthem.b2c_signin exchange '<paste-msauth-url>'
# Prints the refresh_token. Paste it into HA's integration config form.
```

After that, HA silently refreshes the token on every coordinator update and persists the rotated value back to the entry — no further user action until/unless Kohler revokes the refresh_token (at which point HA fires the reauth flow automatically).

## Migration

Existing integration entries don't have a `b2c_refresh_token` set. `async_setup_entry` raises `ConfigEntryAuthFailed` on load, which causes HA to show "Reauth required" in the UI. The user clicks Reauth → enters the refresh_token from the b2c_signin helper → integration reloads with writes working.

No data loss; all other config (username/password/api keys/tenant_id) is preserved.

## Test plan

- [ ] Add a new config entry from scratch, verify writes work end-to-end
- [ ] Restart HA after the entry runs for a few minutes (so the refresh_token has rotated at least once); confirm reads + writes still work after restart
- [ ] Edit `/Volumes/ring/env/kohler.env` to put an obviously-bad refresh_token; restart HA; confirm reauth flow fires and accepts a fresh token
- [ ] Test outlet toggle: water flowed from physical outlet 2 → confirmed working at the library level via `kohler_anthem`'s `test_library_writes.py`