### PR TITLE
chore(config): explicitly accept b2c_refresh_token in YAML schema

### DIFF
--- a/custom_components/kohler_anthem/__init__.py
+++ b/custom_components/kohler_anthem/__init__.py
@@ -52,6 +52,10 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Required(CONF_CLIENT_ID): cv.string,
                 vol.Required(CONF_APIM_KEY): cv.string,
                 vol.Required(CONF_API_RESOURCE): cv.string,
+                # Optional in YAML so existing configs keep importing cleanly.
+                # If absent, async_setup_entry raises ConfigEntryAuthFailed and
+                # HA prompts the user to reauth with a freshly-captured token.
+                vol.Optional(CONF_B2C_REFRESH_TOKEN): cv.string,
             }
         )
     },


### PR DESCRIPTION
## Summary

Adds \`b2c_refresh_token\` as an explicit \`vol.Optional\` field in the YAML \`CONFIG_SCHEMA\`. Previously it relied on \`extra=vol.ALLOW_EXTRA\` to pass through.

## Why

Users who store the refresh token in \`secrets.yaml\` and reference it via \`!secret kohler_b2c_refresh_token\` from their \`configuration.yaml\` get a clean, documented import path. The voluptuous schema also shows the field to anyone reading the integration source.

## Migration

Zero-impact for existing entries. The field is **Optional** — YAML configs without it import the same way they did before. If the imported entry ends up without a refresh_token, \`async_setup_entry\` raises \`ConfigEntryAuthFailed\` and HA prompts the user to reauth via the UI (same flow as the 0.3.0 upgrade).

## Test plan

- [ ] YAML config with \`b2c_refresh_token: !secret kohler_b2c_refresh_token\` imports cleanly
- [ ] YAML config without the field still imports (and triggers reauth on first write)
- [ ] UI-driven config flow unaffected